### PR TITLE
He quitado los bloqueos de acceso dentro del S3 y modifique el alb

### DIFF
--- a/alb.tf
+++ b/alb.tf
@@ -1,9 +1,35 @@
+resource "aws_security_group" "alb_sg" {
+  name        = "alb-security-group"
+  description = "Permite trafico HTTP al ALB"
+  vpc_id      = aws_vpc.main_vpc.id
+
+  ingress {
+    description = "Trafico HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "Todo el trafico de salida permitido"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "sg-alb-govench"
+  }
+}
+
 # Application Load Balancer (ALB)
 resource "aws_lb" "app_alb" {
   name               = "alb-govench"
   internal           = false
   load_balancer_type = "application"
-  security_groups    = [] # Por ahora vacío luego crearemos un Security Group :)
+  security_groups    = [aws_security_group.alb_sg.id]
   subnets            = [
     aws_subnet.public_a.id,
     aws_subnet.public_b.id

--- a/s3.tf
+++ b/s3.tf
@@ -3,6 +3,43 @@ resource "aws_s3_bucket" "mi_bucket_web" {
 
   website {
     index_document = "index.html"
-    error_document = "error.html"
+    error_document = "index.html"
+
+    routing_rules = jsonencode([
+      {
+        Condition = {
+          HttpErrorCodeReturnedEquals = "404"
+        },
+        Redirect = {
+          ReplaceKeyWith = "index.html"
+        }
+      }
+    ])
   }
+}
+
+resource "aws_s3_bucket_policy" "bucket_public_policy" {
+  bucket = aws_s3_bucket.mi_bucket_web.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "PublicReadGetObject"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = "s3:GetObject"
+        Resource  = "${aws_s3_bucket.mi_bucket_web.arn}/*"
+      }
+    ]
+  })
+}
+
+resource "aws_s3_bucket_public_access_block" "no_block" {
+  bucket = aws_s3_bucket.mi_bucket_web.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
 }


### PR DESCRIPTION
**alb_sg:** Nuevo security group que permite HTTP público (puerto 80) y todo el tráfico de salida.

**aws_lb:** Ahora incluye el security group (alb_sg) y usa subredes públicas.

**s3.tf:**

- Se agregó redirección 404 → index.html (útil para SPAs).
- Se añadió política pública para permitir lectura desde el navegador.
- Se desactivaron bloqueos para permitir acceso público.
